### PR TITLE
Better cookie handling

### DIFF
--- a/plugin.video.videodevil/lib/galleryparser.py
+++ b/plugin.video.videodevil/lib/galleryparser.py
@@ -33,13 +33,15 @@ imgDir = os.path.join(resDir, 'images')
 catDir = os.path.join(resDir, 'catchers')
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar()
+cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
 Request = urllib2.Request
 USERAGENT = 'Mozilla/5.0 (Windows; U; Windows NT 5.2; en-GB; rv:1.8.1.18) Gecko/20081029 Firefox/2.0.0.18'
 
 if cj != None:
-    if os.path.isfile(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp'))):
-        cj.load(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+    try:
+        cj.load()
+    except:
+        pass
     opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
     urllib2.install_opener(opener)
 else:
@@ -323,7 +325,7 @@ class CCurrentList:
                     traceback.print_exc(file = sys.stdout)
                 return
             data = handle.read()
-            cj.save(os.path.join(settingsDir, 'cookies.lwp'))
+            cj.save()
             site.status['web_response'] = 'Successfully fetched'
             if enable_debug:
                 f.write(data)

--- a/plugin.video.videodevil/lib/galleryparser.py
+++ b/plugin.video.videodevil/lib/galleryparser.py
@@ -33,7 +33,7 @@ imgDir = os.path.join(resDir, 'images')
 catDir = os.path.join(resDir, 'catchers')
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+cj = cookielib.MozillaCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.txt')))
 Request = urllib2.Request
 USERAGENT = 'Mozilla/5.0 (Windows; U; Windows NT 5.2; en-GB; rv:1.8.1.18) Gecko/20081029 Firefox/2.0.0.18'
 

--- a/plugin.video.videodevil/lib/remoteparser.py
+++ b/plugin.video.videodevil/lib/remoteparser.py
@@ -31,7 +31,7 @@ enable_debug = sys.modules["__main__"].enable_debug
 log = sys.modules["__main__"].log
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+cj = cookielib.MozillaCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.txt')))
 Request = urllib2.Request
 
 if cj != None:

--- a/plugin.video.videodevil/lib/remoteparser.py
+++ b/plugin.video.videodevil/lib/remoteparser.py
@@ -31,12 +31,14 @@ enable_debug = sys.modules["__main__"].enable_debug
 log = sys.modules["__main__"].log
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar()
+cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
 Request = urllib2.Request
 
 if cj != None:
-    if os.path.isfile(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp'))):
-        cj.load(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+    try:
+        cj.load()
+    except:
+        pass
     opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
     urllib2.install_opener(opener)
 else:
@@ -520,6 +522,6 @@ class remoteParser:
         elif len(tasks) == 1:
             self.items = loadRemote(*fetchHTML(*tasks[0]))
         print "Elapsed Time: %s" % (time.clock() - start)
-        cj.save(os.path.join(settingsDir, 'cookies.lwp'))
+        cj.save()
         return self.items
 

--- a/plugin.video.videodevil/lib/videoparser.py
+++ b/plugin.video.videodevil/lib/videoparser.py
@@ -27,7 +27,7 @@ log = sys.modules["__main__"].log
 USERAGENT = 'Mozilla/5.0 (Windows; U; Windows NT 5.2; en-GB; rv:1.8.1.18) Gecko/20081029 Firefox/2.0.0.18'
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+cj = cookielib.MozillaCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.txt')))
 Request = urllib2.Request
 
 if cj != None:

--- a/plugin.video.videodevil/lib/videoparser.py
+++ b/plugin.video.videodevil/lib/videoparser.py
@@ -27,12 +27,14 @@ log = sys.modules["__main__"].log
 USERAGENT = 'Mozilla/5.0 (Windows; U; Windows NT 5.2; en-GB; rv:1.8.1.18) Gecko/20081029 Firefox/2.0.0.18'
 
 urlopen = urllib2.urlopen
-cj = cookielib.LWPCookieJar()
+cj = cookielib.LWPCookieJar(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
 Request = urllib2.Request
 
 if cj != None:
-    if os.path.isfile(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp'))):
-        cj.load(xbmc.translatePath(os.path.join(settingsDir, 'cookies.lwp')))
+    try:
+        cj.load()
+    except:
+        pass
     opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
     urllib2.install_opener(opener)
 else:


### PR DESCRIPTION
Some sites are sending cookies with expiration date far in the future. This causes trouble when LWPCookieJar is used to process cookies on 32bit system (or more precise system that uses 32bit time_t values).

Problem is well described here:
http://bugs.python.org/issue5537

This patch replaces LWPCookieJar by MozillaCookieJar that doesn't have such problem.
