### PR TITLE
Modified merged code from ge0rdi (Thanks,your code was much cleaner, hop...

### DIFF
--- a/plugin.video.videodevil/lib/utils/encodingUtils.py
+++ b/plugin.video.videodevil/lib/utils/encodingUtils.py
@@ -8,24 +8,37 @@ from lib.common import smart_unicode
 
 enable_debug = sys.modules["__main__"].enable_debug
 
+name2unicode = dict((unicode(key),unichr(htmlentitydefs.name2codepoint[key])) for key in htmlentitydefs.name2codepoint.keys())
+name2unicode[u'apos'] = u"'"
+
+decode_pattern = re.compile(r'&(#?[a-zA-Z0-9]+);') # more specific(\w is shorter but contains "_"), avoids matching "& jane; and won't skip "& jane&#039;s"
+
 def decode(s):
     if not s:
         return ''
     def sub(m):
-        if htmlentitydefs.name2codepoint.has_key(m.group(1)):
-            return unichr(htmlentitydefs.name2codepoint[m.group(1)])
+        if m.group(1).startswith(u'#'):
+            if m.group(1)[1] == u'x': # &#xXXX
+                return unichr(int(text[3:-1], 16))
+            return unichr(int(m.group(1)[1:]))
+        elif name2unicode.has_key(m.group(1)):
+            return unichr(name2unicode[m.group(1)])
         else:
-            return ''
-    return re.sub(r'&([^;]+);', sub, s)
+            return m.group(0) # false match(i.e. "&jane;") return as is
+    return decode_pattern.sub(sub, s)
 
 def clean_safe(s):
     if not s:
         return ''
     try:
         o = smart_unicode(s)
-        # remove &#XXX;
-        o = re.sub(r'&#(\d+);', lambda m: unichr(int(m.group(1))), o)
-        # remove &XXX;
+        # remove any number of "amp;"
+        #&amp;/&amp;amp; --> &
+        #&amp;#XXX/&amp;amp;#XXX --> &#XXX
+        #&amp;XXX/&amp;amp;XXX --> &XXX
+        #&amp; jane&amp;&#039;s  -->  & jane&#039;s
+        o = o.replace(u'amp;', u'')
+        # remove &#XXX; and &XXX;
         o = decode(o)
         # remove \uXXX
         o = re.sub(r'\\u(....)', lambda m: unichr(int(m.group(1), 16)), o)


### PR DESCRIPTION
...e you don't mind the changes), changed re.sub in decode(has to compile regex everytime decode is called) to a regex object and pulled re.compile out of decode(now its only compiled once.

combined the re.sub patterns to one pattern to limit the number of times string "s" is parsed over.
Added support for replacing &#xXXXX (http://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references)
Added support for replacing entities that have been encoded multiple times(&amp;#039:).
Handling multiple encoded entities is the tricky part if anyone knows of a better way please let know.
